### PR TITLE
Fix dagger-pipeline connection to dagger SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dagger-sdk",
+ "eyre",
  "tokio",
 ]
 

--- a/crates/dagger-pipeline/Cargo.toml
+++ b/crates/dagger-pipeline/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+eyre = "0.6"
 clap = { version = "4.5", features = ["derive"] }
 dagger-sdk = "0.19.6"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/dagger-pipeline/src/main.rs
+++ b/crates/dagger-pipeline/src/main.rs
@@ -4,13 +4,24 @@ mod cli;
 use anyhow::{Context, Result};
 use args::{Args, CliTarget, Command};
 use clap::Parser;
+use eyre::Report;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let client = dagger_sdk::connect()
-        .await
-        .context("failed to connect to dagger engine")?;
+
+    dagger_sdk::connect(|client| async move {
+        run(client, args)
+            .await
+            .map_err(|err| Report::msg(err.to_string()))
+    })
+    .await
+    .context("failed to connect to dagger engine")?;
+
+    Ok(())
+}
+
+async fn run(client: dagger_sdk::Query, args: Args) -> Result<()> {
     let repo = client.host().directory(".");
 
     match args.command {


### PR DESCRIPTION
## Summary
- update the dagger pipeline binary to use the closure-based dagger_sdk::connect API
- add eyre as a dependency to bridge errors when running the pipeline

## Testing
- cargo run --bin dagger-pipeline -- --help
- cargo clippy --bin dagger-pipeline -- -D warnings
- cargo test -p dagger-pipeline

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d9419e0c832085a6594f44adccaf)